### PR TITLE
Seminars rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ _site/**
 _site
 fullcalendar/
 fullcalendar/*
+.Rproj.user/
+*.Rproj

--- a/Seminars.md
+++ b/Seminars.md
@@ -6,7 +6,7 @@
     {% for post in site.posts %}
     {% if post.categories contains "seminars"%}
         <li>
-            <a href="{{ "/" | absolute_url }}{{ post.url }}">{{ post.date }}, {{ post.title }}</a>
+            <a href="{{ "/" | absolute_url }}{{ post.url }}">{{ post.date | date: "%-d %B %Y"}}, {{ post.title }}</a>
         </li>
     {% endif %}
     {% endfor %}

--- a/Seminars.md
+++ b/Seminars.md
@@ -2,11 +2,9 @@
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`  
 **TIME:** Wednesdays 1-2 PM  
-**LOCATION:** ATRF D-3001 CONFERENCE ROOM  
-  
-  
-**WebEx Information:**
-https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a 
+**LOCATION:** ATRF D-3001 Conference Room
+**[Join via WebEx](https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a)**
+
 
 ## Upcoming 
 

--- a/Seminars.md
+++ b/Seminars.md
@@ -1,80 +1,33 @@
 # Seminars
 
-## Upcoming Seminars
+## Upcoming
 
 <ul>
-    {% for post in site.posts %}
+    {% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}
+    {% for post in site.posts reversed %}
     {% if post.categories contains "seminars"%}
-        <li>
-            <a href="{{ "/" | absolute_url }}{{ post.url }}">{{ post.date | date: "%-d %B %Y"}}, {{ post.title }}</a>
-        </li>
+        {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
+        {% if posttime > nowunix %}
+            <li>
+                <a href="{{ "/" | absolute_url }}{{ post.url }}">{{ post.date | date: "%-d %B %Y"}}, {{ post.title }}</a>
+            </li>
+        {% endif %}
     {% endif %}
     {% endfor %}
 </ul>
 
-## Upcoming 
-
-| Date | Meeting Type | Speaker | Topic | 
-| ------ | ------ | ------ | ------ |
-| 11/21/18 | **Cancelled** | **Cancelled** | CCBR_NCBR Potluck Lunch |
-| 11/28/18 | Journal Club | Mayank | TBA |
-| 12/5/18 | TechDev | Vishal, Skyler, Tovah, Alexei | ChIP-seq + ATAC-seq |
-| 12/12/18 | Journal Club | Paul | TBA |
-| 12/19/18 | TechDev | Vishal, Skyler, Nathan, Paul | RNA-seq + miR-seq |
-| 12/26/18 | Journal Club | Tovah | TBA |
-| 1/2/19 | TechDev | Justin, Keyur | Exomeseq + WGS |
-| 1/9/19 | Journal Club | Arun | TBA |
-| 1/16/19 | TechDev | Abdalla, Vicky | Single-cell  Applications |
-| 1/23/19 | Journal Club | Sue | TBA |
-| 1/30/19 | TechDev | Jack | Long-read technologies |
-
 ## Previous
 
-| Date | Meeting Type | Speaker | Topic | 
-| ------ | ------ | ------ | ------ |
-| 1/3/18 | Journal Club | Parthav | TBA |
-| 1/10/18 | TechDev | Vishal, Skyler, Nathan, Alexei | ChIP-Seq + miRSeq |
-| 1/17/18 | Training | HPC Staff | HPC DME API updates: demo |
-| 1/24/18 | Journal Club | Abdalla | TBA |
-| 1/31/18 | **Cancelled** | **Cancelled** | **Cancelled** |
-| 2/7/18 | TechDev | Vishal, Skyler | RNA-Seq + Microarray |
-| 2/14/18 | Journal Club | Jack | TBA |
-| 2/21/18 | TechDev | Justin | Exomeseq + WGS |
-| 2/28/18 | Journal Club | Chunhua | TBA |
-| 3/7/18 | **Cancelled** | **Cancelled** | **Cancelled** |
-| 3/14/18 | TechDev | Yongmei | Structural variation: Part I |
-| 3/21/18 | **Cancelled** | **Cancelled** | **Cancelled** |
-| 3/28/18 | Journal Club | Alexei | TBA |
-| 4/4/18 | TechDev | Yongmei | Structural variation: Part II |
-| 4/11/18 | Training | Randy | TidyVerse Overview |
-| 4/18/18 | Journal Club | Yongmei | TBA |
-| 4/25/18 | Training | Guest Speaker | Partek Flow training: single-cell RNASeq |
-| 5/2/18 | Journal Club | Ying | TBA |
-| 5/9/18 | TechDev | Vishal, Skyler, Nathan, Alexei | ChIP-Seq + miRSeq |
-| 5/16/18 | Journal Club | Rich | TBA |
-| 5/23/18 | TechDev | Vishal, Skyler | RNA-Seq + Microarray |
-| 5/30/18 | Journal Club | Justin | TBA |
-| 6/6/18 | TechDev | Justin | Exomeseq + WGS |
-| 6/13/18 | Journal Club | Ajeet | TBA |
-| 6/20/18 | TechDev | Nikhil | Single-cell  Applications |
-| 6/27/18 | Journal Club | George | TBA |
-| 7/4/18 | **Cancelled** | **Cancelled** | **Cancelled** |
-| 7/11/18 | **Cancelled** | **Cancelled** | **Cancelled** |
-| 7/18/18 | Other | SF Staff | Sequencing Facility Tour |
-| 7/25/18 | Journal Club | Vishal | TBA |
-| 8/1/18 | **Cancelled** | **Cancelled** | **Cancelled** |
-| 8/8/18 | TechDev | Justin | Structural variation |
-| 8/15/18 | Journal Club | Tsai-Wei | TBA |
-| 8/22/18 | Journal Club | Josh | TBA |
-| 8/29/18 | TechDev | Vishal, Skyler, Nathan, Alexei | ChIP-Seq + miRSeq |
-| 9/5/18 | TechDev | Vishal, Skyler | RNA-Seq + Microarray |
-| 9/12/18 | Journal Club | George | TBA |
-| 9/19/18 | TechDev | Justin | Structural variation |
-| 9/26/18 | TechDev | Guest Speaker | 10X CNV pipeline presentation |
-| 10/3/18 | TechDev | Abdalla, Vicky | Single-cell  Applications |
-| 10/10/18 | Journal Club | Maggie | Reproducibility (Part I) |
-| 10/17/18 | Journal Club | Maggie | Reproducibility (Part II) |
-| 10/24/18 | TechDev | Jack | Long-read technologies |
-| 10/31/18 | Journal Club | Nathan | TBA |
-| 11/7/18 | **Cancelled** | **Cancelled** | RNA Biology symposium |
-| 11/14/18 | TechDev | Justin, Keyur | Exomeseq + WGS |
+<ul>
+    {% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}
+    {% for post in site.posts %}
+    {% if post.categories contains "seminars"%}
+        {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
+        {% if posttime < nowunix %}
+            <li>
+                <a href="{{ "/" | absolute_url }}{{ post.url }}">{{ post.date | date: "%-d %B %Y"}}, {{ post.title }}</a>
+            </li>
+        {% endif %}
+    {% endif %}
+    {% endfor %}
+</ul>

--- a/Seminars.md
+++ b/Seminars.md
@@ -1,10 +1,16 @@
 # Seminars
 
-**PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`  
-**TIME:** Wednesdays 1-2 PM  
-**LOCATION:** ATRF D-3001 Conference Room
-**[Join via WebEx](https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a)**
+## Upcoming Seminars
 
+<ul>
+    {% for post in site.posts %}
+    {% if post.categories contains "seminars"%}
+        <li>
+            <a href="{{ "/" | absolute_url }}{{ post.url }}">{{ post.date }}, {{ post.title }}</a>
+        </li>
+    {% endif %}
+    {% endfor %}
+</ul>
 
 ## Upcoming 
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,9 +23,9 @@
         <p>{{ site.description | default: site.github.project_tagline }}</p>
 
         <p><a href="{{ "/" | absolute_url }}">About</a></p>
-        <p><a href="Contacts">Contacts</a></p>
-        <p><a href="Seminars">Seminars</a></p>
-        <p><a href="Calendar">Calendar</a></p>
+        <p><a href="{{ "/" | absolute_url }}Contacts">Contacts</a></p>
+        <p><a href="{{ "/" | absolute_url }}Seminars">Seminars</a></p>
+        <p><a href="{{ "/" | absolute_url }}Calendar">Calendar</a></p>
 
         {% if site.github.is_user_page %}
         <p class="view"><a href="{{ site.github.owner_url }}">View My GitHub Profile</a></p>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,21 @@
+---
+layout: default
+---
+
+<small>{{ page.date | date: "%-d %B %Y" }}</small>
+<h1>{{ page.title }}</h1>
+
+<p class="view">by {{ page.author | default: "ABCS" }}</p>
+
+{% if post.tags contains "seminars" %}
+**PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`, or anyone else interested in joining us.
+**TIME:** 1-2 PM  
+**LOCATION:** ATRF D-3001 Conference Room
+**[Join via WebEx](https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a)**
+{% endif %}
+
+{{content}}
+
+{% if page.tags %}
+  <small>tags: <em>{{ page.tags | join: "</em> - <em>" }}</em></small>
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,17 +2,10 @@
 layout: default
 ---
 
-<small>{{ page.date | date: "%-d %B %Y" }}</small>
+<small>{{ page.date | date: "%-d %B %Y" }} at {{ page.time }} <br> in {{ page.location }} </small>
 <h1>{{ page.title }}</h1>
 
 <p class="view">by {{ page.author | default: "ABCS" }}</p>
-
-{% if post.tags contains "seminars" %}
-**PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`, or anyone else interested in joining us.
-**TIME:** 1-2 PM  
-**LOCATION:** ATRF D-3001 Conference Room
-**[Join via WebEx](https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a)**
-{% endif %}
 
 {{content}}
 

--- a/_posts/2018-01-03-Journal-Club.md
+++ b/_posts/2018-01-03-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Parthav
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-01-10-TechDev.md
+++ b/_posts/2018-01-10-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Vishal, Skyler, Nathan, Alexei
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+ChIP-Seq + miRSeq

--- a/_posts/2018-01-17-Training.md
+++ b/_posts/2018-01-17-Training.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: Training
+author: HPC Staff
 categories: [seminars]
-tags: [journal club]
+tags: [training]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+HPC DME API updates: demo

--- a/_posts/2018-01-24-Journal-Club.md
+++ b/_posts/2018-01-24-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Abdalla
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-02-07-TechDev.md
+++ b/_posts/2018-02-07-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Vishal, Skyler
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+RNA-Seq + Microarray

--- a/_posts/2018-02-14-Journal-Club.md
+++ b/_posts/2018-02-14-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Jack
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-02-21-TechDev.md
+++ b/_posts/2018-02-21-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Justin
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Exomeseq + WGS

--- a/_posts/2018-02-28-Journal-Club.md
+++ b/_posts/2018-02-28-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Chunhua
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-03-14-TechDev.md
+++ b/_posts/2018-03-14-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Yongmei
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Structural variation: Part I

--- a/_posts/2018-03-28-Journal-Club.md
+++ b/_posts/2018-03-28-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Alexei
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-04-04-TechDev.md
+++ b/_posts/2018-04-04-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Yongmei
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Structural variation: Part II

--- a/_posts/2018-04-11-Training.md
+++ b/_posts/2018-04-11-Training.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: Training
+author: Randy
 categories: [seminars]
-tags: [journal club]
+tags: [training]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+TidyVerse Overview

--- a/_posts/2018-04-18-Journal-Club.md
+++ b/_posts/2018-04-18-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Yongmei
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-04-25-Training.md
+++ b/_posts/2018-04-25-Training.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: Training
+author: Guest Speaker
 categories: [seminars]
-tags: [journal club]
+tags: [training]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Partek Flow training: single-cell RNASeq

--- a/_posts/2018-05-02-Journal-Club.md
+++ b/_posts/2018-05-02-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Ying
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-05-09-TechDev.md
+++ b/_posts/2018-05-09-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Vishal, Skyler, Nathan, Alexei
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+ChIP-Seq + miRSeq

--- a/_posts/2018-05-16-Journal-Club.md
+++ b/_posts/2018-05-16-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Rich
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-05-23-TechDev.md
+++ b/_posts/2018-05-23-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Vishal, Skyler
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+RNA-Seq + Microarray

--- a/_posts/2018-05-30-Journal-Club.md
+++ b/_posts/2018-05-30-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Justin
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-06-06-TechDev.md
+++ b/_posts/2018-06-06-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Justin
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Exomeseq + WGS

--- a/_posts/2018-06-13-Journal-Club.md
+++ b/_posts/2018-06-13-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Ajeet
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-06-20-TechDev.md
+++ b/_posts/2018-06-20-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Nikhil
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Single-cell  Applications

--- a/_posts/2018-06-27-Journal-Club.md
+++ b/_posts/2018-06-27-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: George
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-07-18-Other.md
+++ b/_posts/2018-07-18-Other.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: Other
+author: SF Staff
 categories: [seminars]
-tags: [journal club]
+tags: [other]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Sequencing Facility Tour

--- a/_posts/2018-07-25-Journal-Club.md
+++ b/_posts/2018-07-25-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Vishal
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-08-08-TechDev.md
+++ b/_posts/2018-08-08-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Justin
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Structural variation

--- a/_posts/2018-08-15-Journal-Club.md
+++ b/_posts/2018-08-15-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Tsai-Wei
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-08-22-Journal-Club.md
+++ b/_posts/2018-08-22-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Josh
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-08-29-TechDev.md
+++ b/_posts/2018-08-29-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Vishal, Skyler, Nathan, Alexei
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+ChIP-Seq + miRSeq

--- a/_posts/2018-09-05-TechDev.md
+++ b/_posts/2018-09-05-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Vishal, Skyler
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+RNA-Seq + Microarray

--- a/_posts/2018-09-12-Journal-Club.md
+++ b/_posts/2018-09-12-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: George
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-09-19-TechDev.md
+++ b/_posts/2018-09-19-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Justin
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Structural variation

--- a/_posts/2018-09-26-TechDev.md
+++ b/_posts/2018-09-26-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Guest Speaker
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+10X CNV pipeline presentation

--- a/_posts/2018-10-03-TechDev.md
+++ b/_posts/2018-10-03-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Abdalla, Vicky
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Single-cell  Applications

--- a/_posts/2018-10-10-Journal-Club.md
+++ b/_posts/2018-10-10-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Maggie
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
@@ -10,4 +10,4 @@ time: 1 - 2 PM
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Reproducibility (Part I)

--- a/_posts/2018-10-17-Journal-Club.md
+++ b/_posts/2018-10-17-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Maggie
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
@@ -10,4 +10,4 @@ time: 1 - 2 PM
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Reproducibility (Part II)

--- a/_posts/2018-10-24-TechDev.md
+++ b/_posts/2018-10-24-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Jack
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Long-read technologies

--- a/_posts/2018-10-31-Journal-Club.md
+++ b/_posts/2018-10-31-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Nathan
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-11-14-TechDev.md
+++ b/_posts/2018-11-14-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Justin, Keyur
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Exomeseq + WGS

--- a/_posts/2018-11-28-Journal-Club.md
+++ b/_posts/2018-11-28-Journal-Club.md
@@ -4,6 +4,10 @@ title: Journal Club
 author: Mayank
 categories: [seminars]
 tags: [journal club]
+location: ATRF D-3001 Conference Room or [WebEx](https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a)
+time: 1 - 2 PM
 ---
+
+**PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`, or anyone else interested in joining us.
 
 TBD

--- a/_posts/2018-11-28-Journal-Club.md
+++ b/_posts/2018-11-28-Journal-Club.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: Journal Club
+author: Mayank
+categories: [seminars]
+tags: [journal club]
+---
+
+TBD

--- a/_posts/2018-11-28-Journal-Club.md
+++ b/_posts/2018-11-28-Journal-Club.md
@@ -4,7 +4,7 @@ title: Journal Club
 author: Mayank
 categories: [seminars]
 tags: [journal club]
-location: ATRF D-3001 Conference Room or [WebEx](https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a)
+location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 

--- a/_posts/2018-12-05-TechDev.md
+++ b/_posts/2018-12-05-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Vishal, Skyler, Tovah, Alexei
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+ChIP-seq + ATAC-seq

--- a/_posts/2018-12-12-Journal-Club.md
+++ b/_posts/2018-12-12-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Paul
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2018-12-19-TechDev.md
+++ b/_posts/2018-12-19-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Vishal, Skyler, Nathan, Paul
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+RNA-seq + miR-seq

--- a/_posts/2018-12-26-Journal-Club.md
+++ b/_posts/2018-12-26-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Tovah
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2019-01-02-TechDev.md
+++ b/_posts/2019-01-02-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Justin, Keyur
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Exomeseq + WGS

--- a/_posts/2019-01-09-Journal-Club.md
+++ b/_posts/2019-01-09-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Arun
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2019-01-11-BUF.md
+++ b/_posts/2019-01-11-BUF.md
@@ -4,6 +4,8 @@ title: Bioinformatics User Forum Meeting
 author: Vishal Koparde
 categories: [seminars]
 tags: [BUF, roundtable, NGS pipeline, cloud]
+location: ATRF Auditorium
+time: 1 - 2 PM
 ---
 
 Come join us for our next Bioinformatics User Forum meeting on Jan 11 in the ATRF Auditorium in Frederick. Our main speaker, Vishal Koparde, will be presenting a *use-case on developing an NGS analysis pipeline in the cloud*, and then we will break into small groups for roundtable discussions (see details in the agenda below).

--- a/_posts/2019-01-11-BUF.md
+++ b/_posts/2019-01-11-BUF.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: Bioinformatics User Forum Meeting
+author: Vishal Koparde
+categories: [seminars]
+tags: [BUF, roundtable, NGS pipeline, cloud]
+---
+
+Come join us for our next Bioinformatics User Forum meeting on Jan 11 in the ATRF Auditorium in Frederick. Our main speaker, Vishal Koparde, will be presenting a *use-case on developing an NGS analysis pipeline in the cloud*, and then we will break into small groups for roundtable discussions (see details in the agenda below).
+ 
+We will also have an informal lunch-time gathering in the ATRF Atrium prior to the meeting.
+ 
+## Agenda
+
+* 12:00 - 1:00 Informal lunch gathering in the ATRF Atrium. Bring your lunch and enjoy the company of Bioinformatics User Forum members!
+* 1:00 - 1:20 Vishal Koparde will be presenting a use-case on developing and deploying an NGS analysis pipeline in the cloud.
+* 1:20 - 1:30 Roundtable discussion leaders will present the topics for discussion to the entire group
+* 1:30 - 2:00 Break into small groups for roundtable discussions on the following topics:
+    * Justing Lack will be leading a discussion on tumor variant analysis. Discussion points may include power, study design, tumor subclonality, or other related topics as determined by the group.
+    * Cassandra Philipson will be leading a follow up discussion on [PATRIC](https://patricbrc.org/), which provides integrated data and analysis tools for research on bacterial genomics. Join us if you were able to attend the PATRIC workshop, or if you like to learn more.
+    * Yanling Liu will be leading a discussion on image analysis tools for pathological image analysis. What commercial and open source tools are being used? What have you found to be easy to use, integrates with deep learning tools, connects to visualization tools, etc.? What analysis techniques need better tools?
+ 

--- a/_posts/2019-01-16-TechDev.md
+++ b/_posts/2019-01-16-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Abdalla, Vicky
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Single-cell  Applications

--- a/_posts/2019-01-23-Journal-Club.md
+++ b/_posts/2019-01-23-Journal-Club.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Journal Club
-author: Mayank
+author: Sue
 categories: [seminars]
 tags: [journal club]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>

--- a/_posts/2019-01-30-TechDev.md
+++ b/_posts/2019-01-30-TechDev.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Journal Club
-author: Mayank
+title: TechDev
+author: Jack
 categories: [seminars]
-tags: [journal club]
+tags: [techdev]
 location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>
 time: 1 - 2 PM
 ---
 
 **PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`
 
-TBA
+Long-read technologies

--- a/scripts/parse_Seminars.md.R
+++ b/scripts/parse_Seminars.md.R
@@ -1,0 +1,47 @@
+library(magrittr)
+library(dplyr)
+
+seminars <- readLines('Seminars.md') %>%
+            grep(pattern = "^\\|", value = TRUE) %>%               # pull all lines starting with '|'
+    
+            grep(pattern = "**Cancelled**", fixed = TRUE,          # drop all lines containing **Cancelled**
+                 invert = TRUE, value = TRUE) %>%
+    
+            grep(pattern = 'Date', value = TRUE,                   # drop column headers
+                 invert = TRUE) %>%               
+            grep(pattern = '----', value = TRUE,
+                 invert = TRUE, fixed = TRUE) %>% 
+    
+            strsplit(split = "|", fixed = TRUE) %>%                # split columns
+    
+            sapply(trimws) %>%                                     # trim whitespace and turn into a matrix
+            t() %>%
+
+            as_data_frame()                                        # convert to data_frame
+
+dt <- strsplit(seminars$V2, "/", fixed = TRUE) %>%
+      lapply(function(x) ifelse(as.numeric(x) < 10, paste0(0, x), x))
+
+seminars <- mutate(seminars,
+                   tag = tolower(V3),
+                   fileName = paste0('20', sapply(dt, `[`, 3), '-',    # year
+                                     sapply(dt, `[`, 1), '-',          # month
+                                     sapply(dt, `[`, 2), '-',          # day
+                                     gsub(" ", "-", V3, fixed = TRUE), # title 
+                                     '.md'))
+
+for(i in 1:dim(seminars)[1])
+{
+    cat('---',
+        'layout: post',
+        paste('title:', seminars$V3[i]),
+        paste('author:', seminars$V4[i]),
+        'categories: [seminars]',
+        paste0('tags: [', seminars$tag[i], ']'),
+        'location: ATRF D-3001 Conference Room or <a href="https://cbiit.webex.com/cbiit/e.php?MTID=m8e4cc08aae26be936415c20896d4867a">WebEx</a>',
+        'time: 1 - 2 PM',
+        '---\n',
+        '**PARTICIPATING GROUPS:**  `CCBR`, `NCBR`, `SF-IFX`, `RNA-BIOLOGY`\n',
+        seminars$V5[i],
+        sep = '\n', file = paste0('_posts/', seminars$fileName[i]))
+}


### PR DESCRIPTION
I've rewritten Seminars.md. New seminars can now be added as posts. Upcoming and Previous seminars lists will be automatically updated every time the site is built, so we don't have to manually move seminars from one list to the other.

I have a build available for review at https://johnsonra.github.io/ABCSwebsite-dev/Seminars